### PR TITLE
Remove auto-dns setting

### DIFF
--- a/hosts/dell-xps13/default.nix
+++ b/hosts/dell-xps13/default.nix
@@ -28,12 +28,26 @@
   networking.hostName = "nixos"; # Define your hostname.
 
   networking.networkmanager.enable = true; # Easiest to use and most distros use this by default.
+
+  # Disable NetworkManager's internal DNS resolution
+  networking.networkmanager.dns = "none";
+
+  # These options are unnecessary when managing DNS ourselves
+  networking.useDHCP = false;
+  networking.dhcpcd.enable = false;
+
+  # Configure DNS servers manually (this example uses Cloudflare and Google DNS)
+  # IPv6 DNS servers can be used here as well.
+  networking.nameservers = [
+    "9.9.9.9"
+    "1.1.1.1"
+    "1.0.0.1"
+    "8.8.8.8"
+    "8.8.4.4"
+  ];
   networking.enableIPv6 = false;
 
-  networking.useDHCP = false;
   networking.interfaces.wlp165s0.useDHCP = true;
-
-  networking.nameservers = ["9.9.9.9"];
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";


### PR DESCRIPTION
The DNS provided by the default gateway at home was causing issues, likely related to edns